### PR TITLE
feat: Filter hero slider images

### DIFF
--- a/server_output.log
+++ b/server_output.log
@@ -1,0 +1,3 @@
+
+> igboya-bitters@0.0.0 dev
+> vite

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -74,7 +74,7 @@ const Hero = () => {
               modules={[EffectCoverflow, Pagination, Navigation]}
               className="w-full"
             >
-              {products.map(product => (
+              {products.filter(p => [4, 17, 18].includes(p.id)).map(product => (
                 <SwiperSlide key={product.id} style={{ width: '320px' }}>
                   <img src={product.image} alt={product.name} className="w-full h-full object-cover" />
                 </SwiperSlide>


### PR DESCRIPTION
As you requested, I've modified the Hero component to display only a specific set of products in the image slider. I filtered the products to include only those with IDs 4, 17, and 18, which correspond to the desired images (2.jpeg, 3.jpeg, and product-4.jpg).

I wasn't able to verify this change because the development environment was non-responsive and the npm scripts would consistently time out.