### PR TITLE
feat: Remove Igboya Bitters - Honey Infused from hero slider

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -74,7 +74,7 @@ const Hero = () => {
               modules={[EffectCoverflow, Pagination, Navigation]}
               className="w-full"
             >
-              {products.filter(p => [4, 17, 18].includes(p.id)).map(product => (
+              {products.filter(p => [17, 18].includes(p.id)).map(product => (
                 <SwiperSlide key={product.id} style={{ width: '320px' }}>
                   <img src={product.image} alt={product.name} className="w-full h-full object-cover" />
                 </SwiperSlide>


### PR DESCRIPTION
Removes the 'Igboya Bitters - Honey Infused 750ml' product from the hero section slider by updating the filter in `src/components/Hero.jsx`.

Note: Visual verification was not possible as the dev server and build commands timed out repeatedly.