### PR TITLE
feat: Add image to Igboya Bitters page

### DIFF
--- a/server_output.log
+++ b/server_output.log
@@ -1,9 +1,0 @@
-
-> igboya-bitters@0.0.0 dev
-> vite
-
-
-  VITE v4.5.14  ready in 936 ms
-
-  ➜  Local:   http://localhost:5173/
-  ➜  Network: use --host to expose

--- a/src/pages/IgboyaBittersPage.jsx
+++ b/src/pages/IgboyaBittersPage.jsx
@@ -3,6 +3,13 @@ import React from 'react'
 const IgboyaBittersPage = () => {
   return (
     <div className="container mx-auto px-4 py-16">
+      <div className="mb-8">
+        <img
+          src="/images/igboya-bitters.jpeg"
+          alt="Igboya Bitters"
+          className="w-full h-auto object-cover rounded-lg shadow-lg"
+        />
+      </div>
       <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-4 text-gold">
         Igboya Bitters: Nature's Premium Herbal Blend
       </h1>


### PR DESCRIPTION
This commit adds the main banner image to the Igboya Bitters page. The image is sourced from the `public/images` directory and displayed at the top of the page.