### PR TITLE
feat: Update nav link colors

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -28,7 +28,7 @@ const Header = () => {
     <header 
       className={`fixed w-full z-50 transition-all duration-300 ${
         isSticky 
-          ? 'bg-white shadow-md' 
+          ? 'bg-white shadow-md sticky'
           : isHomePage 
             ? 'bg-transparent' 
             : 'bg-primary-green'
@@ -51,7 +51,7 @@ const Header = () => {
                     to="/" 
                     className={({isActive}) => 
                       `nav-link ${isActive ? 'active' : ''} ${
-                        isSticky ? 'text-gray-800' : 'text-white hover:text-gold'
+                        isSticky ? 'text-gray-800' : 'text-white'
                       }`
                     }
                   >
@@ -63,7 +63,7 @@ const Header = () => {
                     to="/about" 
                     className={({isActive}) => 
                       `nav-link ${isActive ? 'active' : ''} ${
-                        isSticky ? 'text-gray-800' : 'text-white hover:text-gold'
+                        isSticky ? 'text-gray-800' : 'text-white'
                       }`
                     }
                   >
@@ -75,7 +75,7 @@ const Header = () => {
                     to="/products" 
                     className={({isActive}) => 
                       `nav-link ${isActive ? 'active' : ''} ${
-                        isSticky ? 'text-gray-800' : 'text-white hover:text-gold'
+                        isSticky ? 'text-gray-800' : 'text-white'
                       }`
                     }
                   >
@@ -87,7 +87,7 @@ const Header = () => {
                     to="/contact" 
                     className={({isActive}) => 
                       `nav-link ${isActive ? 'active' : ''} ${
-                        isSticky ? 'text-gray-800' : 'text-white hover:text-gold'
+                        isSticky ? 'text-gray-800' : 'text-white'
                       }`
                     }
                   >

--- a/src/index.css
+++ b/src/index.css
@@ -159,9 +159,16 @@ p {
   transition: color 0.3s ease;
 }
 
-.nav-link:hover,
 .nav-link.active {
+  color: var(--white);
+}
+
+.sticky .nav-link.active {
   color: var(--primary-green);
+}
+
+.nav-link:hover {
+  color: var(--gold);
 }
 
 .nav-link::after {


### PR DESCRIPTION
This commit updates the text color of the active navigation link.

- The active link is now white by default.
- When the navigation bar is sticky (after scrolling), the active link is green.