### PR TITLE
feat: add vercel.json to fix redirect issue

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a vercel.json file with a rewrite rule to ensure that all requests are redirected to the index.html file. This is a common configuration for single-page applications and should resolve the issue where clicking on links in the top navigation on a Vercel deployment redirects to a Netlify deployment.