### PR TITLE
feat: Move Igboya Bitters image to bottom and make full-width

### DIFF
--- a/src/pages/IgboyaBittersPage.jsx
+++ b/src/pages/IgboyaBittersPage.jsx
@@ -2,83 +2,85 @@ import React from 'react'
 
 const IgboyaBittersPage = () => {
   return (
-    <div className="container mx-auto px-4 py-16">
-      <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-4 text-gold mt-8">
-        Igboya Bitters: Nature's Premium Herbal Blend
-      </h1>
-      <p className="text-lg md:text-xl mb-6">
-        Discover the Power of Traditional Wellness
-      </p>
-      <p className="mb-4">
-        Igboya Bitters represents the perfect marriage of time-honored herbal wisdom and modern craftsmanship. This premium alcoholic herbal drink is meticulously crafted from a carefully curated selection of natural herbs, each chosen for their unique therapeutic properties and centuries of traditional use.
-      </p>
-      <h2 className="text-2xl font-bold mt-8 mb-4">Artfully Blended for Maximum Potency</h2>
-      <p className="mb-4">
-        Our master blenders have spent years perfecting the precise combination of natural herbs that make Igboya Bitters truly exceptional. Every bottle contains a harmonious blend of potent botanicals, expertly balanced to deliver both exceptional taste and comprehensive wellness benefits.
-      </p>
-      <h2 className="text-2xl font-bold mt-8 mb-4">Comprehensive Health Benefits</h2>
-      <ul className="list-disc list-inside mb-4">
-        <li className="mb-2">
-          <span className="font-bold">Immune System Support</span>
-          <p>Strengthen your body's natural defenses with our powerful blend of immune-boosting herbs. Regular consumption helps fortify your system against common ailments and seasonal challenges.</p>
-        </li>
-        <li className="mb-2">
-          <span className="font-bold">Natural Body Cleanser</span>
-          <p>Experience the purifying power of nature as Igboya Bitters works to cleanse and detoxify your system, promoting overall vitality and well-being.</p>
-        </li>
-        <li className="mb-2">
-          <span className="font-bold">Fertility Enhancement</span>
-          <p>Traditional herbs known for their fertility-supporting properties have been carefully incorporated to support reproductive health naturally.</p>
-        </li>
-        <li className="mb-2">
-          <span className="font-bold">Pain Management Solutions</span>
-          <ul className="list-disc list-inside ml-4">
-            <li>Back Ache Relief: Find comfort from persistent back pain with our targeted herbal formula</li>
-            <li>Waist Pain Remedy: Address lower back and waist discomfort naturally</li>
-            <li>Menstrual Pain Relief: Gentle yet effective support for women's monthly comfort</li>
-          </ul>
-        </li>
-        <li className="mb-2">
-          <span className="font-bold">Digestive Health Support</span>
-          <p>Our specially selected herbs also provide relief for digestive concerns, including support for those dealing with hemorrhoids and related discomfort.</p>
-        </li>
-      </ul>
+    <>
+      <div className="container mx-auto px-4 pt-16 pb-8">
+        <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold mb-4 text-gold mt-8">
+          Igboya Bitters: Nature's Premium Herbal Blend
+        </h1>
+        <p className="text-lg md:text-xl mb-6">
+          Discover the Power of Traditional Wellness
+        </p>
+        <p className="mb-4">
+          Igboya Bitters represents the perfect marriage of time-honored herbal wisdom and modern craftsmanship. This premium alcoholic herbal drink is meticulously crafted from a carefully curated selection of natural herbs, each chosen for their unique therapeutic properties and centuries of traditional use.
+        </p>
+        <h2 className="text-2xl font-bold mt-8 mb-4">Artfully Blended for Maximum Potency</h2>
+        <p className="mb-4">
+          Our master blenders have spent years perfecting the precise combination of natural herbs that make Igboya Bitters truly exceptional. Every bottle contains a harmonious blend of potent botanicals, expertly balanced to deliver both exceptional taste and comprehensive wellness benefits.
+        </p>
+        <h2 className="text-2xl font-bold mt-8 mb-4">Comprehensive Health Benefits</h2>
+        <ul className="list-disc list-inside mb-4">
+          <li className="mb-2">
+            <span className="font-bold">Immune System Support</span>
+            <p>Strengthen your body's natural defenses with our powerful blend of immune-boosting herbs. Regular consumption helps fortify your system against common ailments and seasonal challenges.</p>
+          </li>
+          <li className="mb-2">
+            <span className="font-bold">Natural Body Cleanser</span>
+            <p>Experience the purifying power of nature as Igboya Bitters works to cleanse and detoxify your system, promoting overall vitality and well-being.</p>
+          </li>
+          <li className="mb-2">
+            <span className="font-bold">Fertility Enhancement</span>
+            <p>Traditional herbs known for their fertility-supporting properties have been carefully incorporated to support reproductive health naturally.</p>
+          </li>
+          <li className="mb-2">
+            <span className="font-bold">Pain Management Solutions</span>
+            <ul className="list-disc list-inside ml-4">
+              <li>Back Ache Relief: Find comfort from persistent back pain with our targeted herbal formula</li>
+              <li>Waist Pain Remedy: Address lower back and waist discomfort naturally</li>
+              <li>Menstrual Pain Relief: Gentle yet effective support for women's monthly comfort</li>
+            </ul>
+          </li>
+          <li className="mb-2">
+            <span className="font-bold">Digestive Health Support</span>
+            <p>Our specially selected herbs also provide relief for digestive concerns, including support for those dealing with hemorrhoids and related discomfort.</p>
+          </li>
+        </ul>
 
-      <h2 className="text-2xl font-bold mt-8 mb-4">How to Use Igboya Bitters</h2>
-      <p className="mb-4">
-        For optimal results, follow these simple instructions:
-      </p>
-      <ul className="list-disc list-inside mb-4">
-          <li className="mb-2">
-              <span className="font-bold">Dosage:</span> Take 30ml (one shot) twice daily, preferably before meals.
-          </li>
-          <li className="mb-2">
-              <span className="font-bold">Consistency is Key:</span> For best results, use consistently every day.
-          </li>
-          <li className="mb-2">
-              <span className="font-bold">Shake Well:</span> Always shake the bottle well before use to ensure the herbal ingredients are evenly distributed.
-          </li>
-      </ul>
+        <h2 className="text-2xl font-bold mt-8 mb-4">How to Use Igboya Bitters</h2>
+        <p className="mb-4">
+          For optimal results, follow these simple instructions:
+        </p>
+        <ul className="list-disc list-inside mb-4">
+            <li className="mb-2">
+                <span className="font-bold">Dosage:</span> Take 30ml (one shot) twice daily, preferably before meals.
+            </li>
+            <li className="mb-2">
+                <span className="font-bold">Consistency is Key:</span> For best results, use consistently every day.
+            </li>
+            <li className="mb-2">
+                <span className="font-bold">Shake Well:</span> Always shake the bottle well before use to ensure the herbal ingredients are evenly distributed.
+            </li>
+        </ul>
 
-      <h2 className="text-2xl font-bold mt-8 mb-4">The Igboya Difference</h2>
-      <p className="mb-4">
-        What sets Igboya Bitters apart is our unwavering commitment to quality and authenticity. We source only the finest natural herbs, ensuring that each bottle delivers the full spectrum of benefits that nature intended. Our traditional preparation methods preserve the potency and effectiveness of these time-tested remedies.
-      </p>
-      <h2 className="text-2xl font-bold mt-8 mb-4">Experience Wellness Naturally</h2>
-      <p className="mb-4">
-        Igboya Bitters isn't just a drink – it's a daily wellness ritual that connects you to the healing power of nature. Whether you're seeking to boost your immune system, cleanse your body, or address specific health concerns, our carefully crafted herbal blend offers a natural path to better health.
-      </p>
-      <p className="font-bold">
-        Embrace the wisdom of traditional herbal medicine with Igboya Bitters – where nature meets wellness in every bottle.
-      </p>
-      <div className="mb-8 mt-8">
+        <h2 className="text-2xl font-bold mt-8 mb-4">The Igboya Difference</h2>
+        <p className="mb-4">
+          What sets Igboya Bitters apart is our unwavering commitment to quality and authenticity. We source only the finest natural herbs, ensuring that each bottle delivers the full spectrum of benefits that nature intended. Our traditional preparation methods preserve the potency and effectiveness of these time-tested remedies.
+        </p>
+        <h2 className="text-2xl font-bold mt-8 mb-4">Experience Wellness Naturally</h2>
+        <p className="mb-4">
+          Igboya Bitters isn't just a drink – it's a daily wellness ritual that connects you to the healing power of nature. Whether you're seeking to boost your immune system, cleanse your body, or address specific health concerns, our carefully crafted herbal blend offers a natural path to better health.
+        </p>
+        <p className="font-bold">
+          Embrace the wisdom of traditional herbal medicine with Igboya Bitters – where nature meets wellness in every bottle.
+        </p>
+      </div>
+      <div className="w-full">
         <img
           src="/images/igboya-bitters.jpeg"
           alt="Igboya Bitters"
-          className="w-full h-auto object-cover rounded-lg shadow-lg"
+          className="w-full h-auto object-cover"
         />
       </div>
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
On the Igboya Bitters product page, the `igboya-bitters.jpeg` image has been moved from its position after the header to just before the footer. The image has also been made full-width to improve the page layout and user experience.