### PR TITLE
Fix: Update Igboya Bitters product links

### DIFF
--- a/npm_output.log
+++ b/npm_output.log
@@ -1,4 +1,0 @@
-
-> igboya-bitters@0.0.0 dev
-> vite
-

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -13,7 +13,7 @@ const ProductCard = ({ product, hidePrice }) => {
 
   const isTeKanLe = product.name === 'Te Kan Lee';
   const isFieldMarshal = product.name === 'Field Marshal';
-  const isIgboyaBitters = product.name === 'Igboya Bitters';
+  const isIgboyaBitters = product.name.includes('Igboya Bitters');
 
   const cardLink = isTeKanLe
     ? '/te-kan-le'


### PR DESCRIPTION
The product cards for "Igboya Bitters - Family Pack" and "Igboya Bitters - Ginger Boost 375ml" were not linking to the correct page.

This change modifies the `ProductCard` component to use `includes()` instead of a strict equality check. This ensures that all products with "Igboya Bitters" in their name will correctly link to the `/igboya-bitters` page.