### PR TITLE
The `h1` heading "About Eastwood Edwin Russ Distilleries & Food Limit…

### DIFF
--- a/playwright_output.log
+++ b/playwright_output.log
@@ -1,9 +1,0 @@
-============================= test session starts ==============================
-platform linux -- Python 3.12.11, pytest-8.4.2, pluggy-1.6.0
-rootdir: /app
-plugins: playwright-0.7.1, base-url-2.1.0
-collected 1 item
-
-jules-scratch/verification/verify_sticky_header.py .                     [100%]
-
-============================== 1 passed in 3.42s ===============================

--- a/src/pages/AboutPage.jsx
+++ b/src/pages/AboutPage.jsx
@@ -4,8 +4,6 @@ import { Link } from 'react-router-dom';
 function AboutPage() {
   return (
     <div className="container mx-auto px-4 py-12">
-      <h1 className="text-4xl font-bold text-center mb-8">About Eastwood Edwin Russ Distilleries & Food Limited</h1>
-
       <div className="max-w-4xl mx-auto space-y-8">
         <section>
           <h2 className="text-3xl font-bold mb-4">Overview</h2>


### PR DESCRIPTION
…ed" was removed from the top of the About page.

This change was made because the page title is already communicated through the navigation and the page's content, making the explicit header redundant. The removal simplifies the page layout and improves the user experience by presenting the most relevant content first.