### PR TITLE
feat: apply 5% bottom margin to header

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -38,7 +38,7 @@ const Header = () => {
 
   return (
     <header
-      className={`sticky top-0 w-full z-50 transition-all duration-300 mb-[10%] ${
+      className={`sticky top-0 w-full z-50 transition-all duration-300 mb-[5%] ${
         isSticky
           ? 'bg-white shadow-md'
           : isHomePage


### PR DESCRIPTION
This change applies a 5% bottom margin to the website header section by adding the `mb-[5%]` Tailwind CSS class to the `Header.jsx` component.